### PR TITLE
Updated M98 call to have quotes around the macro name

### DIFF
--- a/bedLevel
+++ b/bedLevel
@@ -18,7 +18,7 @@
 
 
 ; --------------- Header ---------------
-button R0 C0 W63 F0 H1 T"Auto Level" A"M98 P0:/menu/scripts/autoLevel.g"
+button R0 C0 W63 F0 H1 T"Auto Level" A"M98 P""0:/menu/scripts/autoLevel.g"""
 image L"imgs/vline.img"
 button W64 F0 T"Back" A"return"
 image R11 C0 L"imgs/hline.img"
@@ -46,6 +46,6 @@ button C80 T"Off" A"M18"
 
 ; --------------- Move Buttons ---------------
 text C42 W40 H1 R39 T"Move to:"
-button R51 C5 W36 H2 T"Point 1" A"M98 P0:/menu/scripts/goToLevelPoint1.g"
-button C46 W36 H2 T"Point 2" A"M98 P0:/menu/scripts/goToLevelPoint2.g"
-button C90 W36 H2 T"Point 3" A"M98 P0:/menu/scripts/goToLevelPoint3.g"
+button R51 C5 W36 H2 T"Point 1" A"M98 P""0:/menu/scripts/goToLevelPoint1.g"""
+button C46 W36 H2 T"Point 2" A"M98 P""0:/menu/scripts/goToLevelPoint2.g"""
+button C90 W36 H2 T"Point 3" A"M98 P""0:/menu/scripts/goToLevelPoint3.g"""

--- a/changeFilament
+++ b/changeFilament
@@ -30,10 +30,10 @@ text T"°C"
 
 
 ; --------------- Buttons ---------------
-button R32 C0 W45 H1 T"Unload" A"M98 P0:/menu/scripts/unload.g"
+button R32 C0 W45 H1 T"Unload" A"M98 P""0:/menu/scripts/unload.g"""
 button C48 T"-5 " A"T0 G91 G1 E-5 F400"
 button C65 T"+5 " A"T0 G91 G1 E+5 F400"
-button C83 W45 T"Load" A"M98 P0:/menu/scripts/load.g"
+button C83 W45 T"Load" A"M98 P""0:/menu/scripts/load.g"""
 
 
 ; --------------- Print Button---------------


### PR DESCRIPTION
Updated M98 call to have quotes around the macro name for RRF 3.5.1 or above
this commit implemented changes mention by [droftarts](https://github.com/droftarts) in #9 

Since upgrading to RRF 3.5.1, buttons like "Auto Level" in Level bed have stop working 

Credits to [droftarts](https://github.com/droftarts) in #9  and dc42 on duet3D forum [post](https://forum.duet3d.com/topic/35429/3-5rc4-12864-display-menu-m98)

Now I no longer have to get on Duet Web Control every time I run Auto Level😄
